### PR TITLE
Make sure performance example counts quried tree

### DIFF
--- a/samples/performance.rb
+++ b/samples/performance.rb
@@ -9,7 +9,7 @@ class CountingLevenshteinDistancer < BK::LevenshteinDistancer
     @counting = false
   end
 
-  def distance(a, b)
+  def call(a, b)
     @count += 1 if @counting
     super
   end


### PR DESCRIPTION
Teeny fix to make the performance sample properly count how much of the tree was queried.

Thanks for a nice lib!
