### PR TITLE
gem-ify this library, so that projects can more easily include it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+# A sample Gemfile
+source "http://rubygems.org"
+
+gem "text"
+
+group :test do
+  gem "test-unit"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-# A sample Gemfile
 source "http://rubygems.org"
 
 gem "text"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # BK-Tree implementation in Ruby
 
-If you don’t know what a BK-tree is, these links should provide a good explanation and introduction.
+BK-trees can be used to efficiently locate strings' best matches from within a large set. If you don’t know what a BK-tree is, these links should provide a good explanation and introduction.
 
 * [Damn Cool Algorithms, Part 1: BK-Trees](http://blog.notdot.net/2007/4/Damn-Cool-Algorithms-Part-1-BK-Trees)
 * [Fast Approximate String Matching in a Dictionary](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.21.3317)
+
+
+## Installation
+
+BK is available as a ruby gem:
+
+    gem install bk
 
 ## Usage
 
@@ -75,3 +82,15 @@ As the threshold increases, the benefit is reduced. At threshold 3:
 
 * Memory usage: around 6 MB for a 20,000-word tree.
 * Maximum tree depth is limited by the stack.
+
+## Testing
+
+    rake test
+
+...or, for specific tests:
+
+    ruby test/test_building_tree.rb
+
+## License
+
+(TO DO)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+desc "Run all tests"
+task :test do
+  $:.unshift './test'
+  require 'test_all.rb'
+end
+
+task :default => :test
+
+desc "Open an irb session preloaded with this library"
+task :console do
+  sh "irb -Ilib -rbk"
+end

--- a/bk.gemspec
+++ b/bk.gemspec
@@ -1,0 +1,21 @@
+$LOAD_PATH.unshift 'lib'
+require "bk/version"
+
+Gem::Specification.new do |s|
+  s.name              = "bk"
+  s.version           = BK::VERSION
+  s.date              = Time.now.strftime('%Y-%m-%d')
+  s.summary           = "Burkhard Keller Tree implementation in Ruby"
+  s.homepage          = "https://github.com/threedaymonk/bktree"
+  s.email             = "pbattley@gmail.com"
+  s.authors           = [ "Paul Battley" ]
+  s.has_rdoc          = false
+
+  s.files             = %w( README.md Gemfile )
+  s.files            += Dir.glob("lib/**/*") + Dir.glob("samples/**/*")
+  s.test_files        = Dir.glob("test/**/*")
+  s.description       = "Burkhard Keller Tree implementation in Ruby"
+  
+  s.add_dependency("text")
+  s.add_development_dependency("test-unit")
+end

--- a/lib/bk/version.rb
+++ b/lib/bk/version.rb
@@ -1,0 +1,3 @@
+module BK
+  VERSION = '0.0.1'
+end

--- a/test/test_all.rb
+++ b/test/test_all.rb
@@ -1,3 +1,3 @@
-Dir[ File.join( File.dirname(__FILE__), '*.rb' )].each do |f|
-  require f
+Dir.glob("test/test_*.rb").each do |file|
+  require "./#{file}"
 end


### PR DESCRIPTION
Hi,
I'd like to use this library, so went ahead and made it more easily consumable as a gem. Specifically:
- added a minimal .gemspec file
- added a Gemfile
- added a Rakefile that runs all tests by default (and documented the change)
- renamed the repo to `bk` (to match the library's naming structure)
- pushed the `bk` gem to rubygems.org, for easier installation via `gem install bk`

Also, would it be OK to include a license (such as the MIT license: http://www.opensource.org/licenses/mit-license.php)? I'd be happy to add it.
