### PR TITLE
Collapse equal terms.

### DIFF
--- a/lib/bk/dump.rb
+++ b/lib/bk/dump.rb
@@ -3,11 +3,12 @@ require 'bk'
 module BK
   module Dumpable
     def dump
-      if children.any?
-        [term, children.inject({}){ |h,(score,child)| h[score] = child.dump; h }]
-      else
-        [term]
-      end
+      children_dump = children.inject({}){ |h,(score,child)| h[score] = child.dump; h }
+      [
+        term,
+        equal_terms.empty? ? nil : equal_terms,
+        children_dump.empty? ? nil : children_dump
+      ].compact
     end
   end
 

--- a/test/test_building_tree.rb
+++ b/test/test_building_tree.rb
@@ -62,4 +62,14 @@ class BKTreeBuildingWhiteBoxTest < Test::Unit::TestCase
       tree.dump
     )
   end
+
+  def test_should_add_duplicate_terms
+    %w[ book book book book book ].each do |word|
+      tree.add(word)
+    end
+    assert_equal(
+      [ 'book', [ 'book', 'book', 'book', 'book' ]],
+      tree.dump
+    )
+  end
 end

--- a/test/test_querying_tree.rb
+++ b/test/test_querying_tree.rb
@@ -82,3 +82,24 @@ class BKTreeSearchSpaceTest < Test::Unit::TestCase
     assert_equal expected, distancer.history
   end
 end
+
+class BKTreeSearchDuplicateTest < Test::Unit::TestCase
+
+  RandomStruct = Struct.new(:string, :random)
+
+  class RandomStructLevenshteinDistancer
+    def call(a, b)
+      Text::Levenshtein.distance(a.string, b.string)
+    end
+  end
+
+  def test_should_handle_many_duplicates
+    tree = BK::Tree.new(RandomStructLevenshteinDistancer.new)
+
+    10000.times do
+      tree.add(RandomStruct.new('dupe', rand))
+    end
+
+    assert_equal 10000, tree.query(RandomStruct.new('dupe', rand), 0).length
+  end
+end


### PR DESCRIPTION
Creating a tree with many duplicate elements causes the tree to become
degenerate (structure A -> A -> A -> A), which is memory and time
inefficient when the tree needs to query or add to this structure. We
can collapse terms equal to the term of the current node into that node
to avoid this. By the triangle inequality, any node equal to the current
node will meet the threshold if the current node meets the threshold as
well.

Making this change speeds up insertion and querying of duplicate entries
as well as significantly reducing memory footprint.
